### PR TITLE
Update database

### DIFF
--- a/dbt_copilot_python/database.py
+++ b/dbt_copilot_python/database.py
@@ -29,3 +29,17 @@ def database_from_env(environment_key, **extra_keys):
     """
 
     return {"default": setup_database(environment_key, **extra_keys)}
+
+
+def database_url_from_env(environment_key):
+    """
+    Set up the default database URL from a Copilot database environment
+    variable.
+
+    Usage in settings.py:
+
+    DATABASES = { 'default': dj_database_url.config(default=database_url_from_env("MY_DATABASE")) }
+    """
+    config = json.loads(os.environ[environment_key])
+
+    return "{engine}://{username}:{password}@{host}:{port}/{dbname}".format(**config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt-copilot-python"
-version = "0.1.0"
+version = "0.1.1"
 description = "Helper functions to run Django and Flask applications in AWS Copilot/ECS."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 readme = "README.md"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3,6 +3,7 @@ import os
 from unittest.mock import patch
 
 from dbt_copilot_python.database import database_from_env
+from dbt_copilot_python.database import database_url_from_env
 from dbt_copilot_python.database import setup_database
 
 TEST_CONN = {
@@ -48,3 +49,11 @@ def test_database_from_env():
         assert database_from_env("DATABASE_CONFIG") == {
             "default": setup_database("DATABASE_CONFIG")
         }
+
+
+def test_database_url_from_env():
+    with patch.dict(os.environ, {"DATABASE_CONFIG": json.dumps(TEST_CONN)}, clear=True):
+        assert (
+            database_url_from_env("DATABASE_CONFIG")
+            == "postgres://postgres:test-password@hostname.com:5432/main"
+        )


### PR DESCRIPTION
## Context

- Add `database_url_from_env` method
  - Set up the default database URL from a Copilot database environment variable.
  - Relies on `dj-database-url` package as a dependency.

## Question(s)

1. Do we want to remove the other database methods or leave them as is?

## Additional information

A subsequent PR will be created to update documentation as the version will also need to be bumped.